### PR TITLE
Add optional default path to Vagrantfile

### DIFF
--- a/vagrant.el
+++ b/vagrant.el
@@ -83,11 +83,14 @@
   (interactive)
   (find-file (vagrant-locate-vagrantfile)))
 
+(defvar-local vagrant-vagrantfile nil
+  "Default path to Vagrantfile")
 
 (defun vagrant-locate-vagrantfile (&optional dir)
   "Find Vagrantfile for DIR."
   (or (locate-dominating-file (or dir default-directory) "Vagrantfile")
-      (error "No Vagrantfile found in %s or any parent directory" dir)))
+      (or vagrant-vagrantfile
+          (error "No Vagrantfile found in %s or any parent directory" dir))))
 
 (defun vagrant-command (cmd)
   "Run the vagrant command CMD in an async buffer."


### PR DESCRIPTION
vagrant-vagrantfile is a buffer-local variable
meant for use via .dir-locals.el in projects
that don't have a top-level Vagrantfile
