### PR TITLE
Add multi-machine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-vagrant.el
-==========
+# vagrant.el
 
-Manage a vagrant box from emacs
+## Synopsis
+
+Manage Vagrant boxes from Emacs.
 
 This package lets you send vagrant commands while working within a
 project containing a Vagrantfile.
@@ -11,7 +12,25 @@ and assume this is the box you want to work with. It can be handy
 to bring a box up, (re)provision, or even ssh to without leaving
 emacs.
 
+## Installation
+
+If you have a recent Emacs with `package.el`, you can install `vagrant`
+from [MELPA](http://melpa.milkbox.net/).
+
+Or via [el-get](http://tapoueh.org/emacs/el-get.html)
+
+Or manually add to your emacs `load-path`.
+
+## Usage
+
 The emacs command `vagrant-up` will run `vagrant up` in a shell, other
 commands follow the pattern `vagrant-X` emacs command runs `vagrant X`
 in the shell. An exception is vagrant-edit, which will open the
 Vagrantfile for editing.
+
+When vagrant commands are given a prefix, you will be prompted for a
+box name.  For example: <kbd>C-u M-x vagrant-up</kbd>
+
+## See also
+
+* [vagrant-tramp](https://github.com/dougm/vagrant-tramp)

--- a/vagrant.el
+++ b/vagrant.el
@@ -94,8 +94,20 @@
 
 (defun vagrant-command (cmd)
   "Run the vagrant command CMD in an async buffer."
-  (let ((default-directory (file-name-directory (vagrant-locate-vagrantfile))))
-    (async-shell-command cmd "*Vagrant*")))
+  (let ((default-directory (file-name-directory (vagrant-locate-vagrantfile)))
+        (name (if current-prefix-arg
+                  (ido-completing-read "Vagrant box: " (vagrant-box-list)))))
+    (async-shell-command (if name (concat cmd " " name) cmd) "*Vagrant*")))
+
+(defun vagrant-box-list ()
+  "List of vagrant box names."
+  (let ((dir ".vagrant/machines/"))
+    (delq nil
+          (mapcar (lambda (name)
+                    (and (not (member name '("." "..")))
+                         (file-directory-p (concat dir name))
+                         name))
+                  (directory-files dir)))))
 
 (provide 'vagrant)
 


### PR DESCRIPTION
Using a prefix command (such as C-u) allows you to choose a specific
box to manage within a multi-machine environment.

Originally tried using 'vagrant status --machine-readable' for the box
name list, but directory listing is much faster.

Added some doc to the README.
