### PR TITLE
Use completing-read instead of ido-completing-read

### DIFF
--- a/vagrant.el
+++ b/vagrant.el
@@ -96,7 +96,7 @@
   "Run the vagrant command CMD in an async buffer."
   (let ((default-directory (file-name-directory (vagrant-locate-vagrantfile)))
         (name (if current-prefix-arg
-                  (ido-completing-read "Vagrant box: " (vagrant-box-list)))))
+                  (completing-read "Vagrant box: " (vagrant-box-list)))))
     (async-shell-command (if name (concat cmd " " name) cmd) "*Vagrant*")))
 
 (defun vagrant-box-list ()


### PR DESCRIPTION
I'd like to thank @dougm for his multi-machine work, it's very handy.  As a tweak, I'm proposing using plain `completing-read` instead of hard-coding `ido-completing-read`.

Ido users will still get the behaviour they're used to via hooking into `completing-read-function`, and similarly helm users can still use helm.  Explicitly using `ido-completing-read` forces `ido` on everyone and removes this flexibility.
