### PR TITLE
Bugfix: let* not let, to bind default-directory

### DIFF
--- a/vagrant.el
+++ b/vagrant.el
@@ -94,9 +94,9 @@
 
 (defun vagrant-command (cmd)
   "Run the vagrant command CMD in an async buffer."
-  (let ((default-directory (file-name-directory (vagrant-locate-vagrantfile)))
-        (name (if current-prefix-arg
-                  (completing-read "Vagrant box: " (vagrant-box-list)))))
+  (let* ((default-directory (file-name-directory (vagrant-locate-vagrantfile)))
+         (name (if current-prefix-arg
+                   (completing-read "Vagrant box: " (vagrant-box-list)))))
     (async-shell-command (if name (concat cmd " " name) cmd) "*Vagrant*")))
 
 (defun vagrant-box-list ()


### PR DESCRIPTION
The first let clause binds default-directory, but with a plain `let`
this isn't in the scope of the second clause using `vagrant-box-list`.
