### PR TITLE
Specify customize variable type

### DIFF
--- a/vagrant.el
+++ b/vagrant.el
@@ -28,7 +28,8 @@
 
 (defcustom vagrant-up-options ""
   "Options to run vagrant up command"
-  :group 'vagrant)
+  :group 'vagrant
+  :type 'string)
 
 (defcustom vagrant-project-directory "~/vagrant"
   "The path to a Vagrant sandbox."


### PR DESCRIPTION
This fixes the following byte-compile warning.

```
vagrant.el:29:12: Warning: defcustom for ‘vagrant-up-options’ fails to specify
    type
```